### PR TITLE
Ci build failures

### DIFF
--- a/examples/workflows_extensions_example/common/step_types/external_step.ts
+++ b/examples/workflows_extensions_example/common/step_types/external_step.ts
@@ -9,6 +9,7 @@
 
 import { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { StepCategory } from '@kbn/workflows';
 import { i18n } from '@kbn/i18n';
 
 /**
@@ -57,7 +58,7 @@ export const externalStepCommonDefinition: CommonStepDefinition<
   typeof ConfigSchema
 > = {
   id: ExternalStepTypeId,
-  category: 'external',
+  category: StepCategory.External,
   label: i18n.translate('workflowsExtensionsExample.externalStep.label', {
     defaultMessage: 'External Step',
   }),

--- a/examples/workflows_extensions_example/common/step_types/setvat_step.ts
+++ b/examples/workflows_extensions_example/common/step_types/setvat_step.ts
@@ -9,6 +9,7 @@
 
 import { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { StepCategory } from '@kbn/workflows';
 import { i18n } from '@kbn/i18n';
 
 /**
@@ -45,7 +46,7 @@ export const setVarStepCommonDefinition: CommonStepDefinition<
   SetVarStepOutputSchema
 > = {
   id: SetVarStepTypeId,
-  category: 'data',
+  category: StepCategory.Data,
   label: i18n.translate('workflowsExtensionsExample.setVarStep.label', {
     defaultMessage: 'Set Variable',
   }),

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.test.ts
@@ -8,7 +8,7 @@
  */
 
 import type { EuiThemeComputed } from '@elastic/eui';
-import { isDynamicConnector } from '@kbn/workflows';
+import { isDynamicConnector, StepCategory } from '@kbn/workflows';
 import type { WorkflowsExtensionsPublicPluginStart } from '@kbn/workflows-extensions/public';
 import { z } from '@kbn/zod/v4';
 import { flattenOptions, getActionOptions } from './get_action_options';
@@ -25,6 +25,14 @@ jest.mock('../../../trigger_schemas', () => ({
 }));
 jest.mock('@kbn/workflows', () => ({
   isDynamicConnector: jest.fn(),
+  StepCategory: {
+    Elasticsearch: 'elasticsearch',
+    External: 'external',
+    Ai: 'ai',
+    Kibana: 'kibana',
+    Data: 'data',
+    FlowControl: 'flowControl',
+  },
 }));
 jest.mock('../../../shared/ui/step_icons/get_step_icon_type', () => ({
   getStepIconType: jest.fn(),
@@ -116,7 +124,7 @@ describe('getActionOptions', () => {
       label: 'Custom Connector Label',
       description: 'Custom Connector Description',
       icon: 'customIcon',
-      actionsMenuCatalog: 'kibana' as const,
+      category: StepCategory.Kibana,
       inputSchema: z.object({}),
       outputSchema: z.object({}),
     };
@@ -292,7 +300,7 @@ describe('getActionOptions', () => {
     }
   });
 
-  it('should use default catalog when custom step definition has no catalog', () => {
+  it('should add connectors to the correct group based on category', () => {
     const mockConnector = {
       type: 'custom.connector',
       description: 'Custom Connector',
@@ -303,6 +311,7 @@ describe('getActionOptions', () => {
       label: 'Custom Connector Label',
       description: 'Custom Connector Description',
       icon: 'customIcon',
+      category: StepCategory.External,
       inputSchema: z.object({}),
       outputSchema: z.object({}),
     };
@@ -311,11 +320,12 @@ describe('getActionOptions', () => {
     mockWorkflowsExtensions.getStepDefinition.mockReturnValue(mockStepDefinition as any);
 
     const result = getActionOptions(mockEuiTheme, mockWorkflowsExtensions);
-    const kibanaGroup = result.find((group) => group.id === 'kibana');
+    const externalGroup = result.find((group) => group.id === 'external');
 
-    expect(kibanaGroup).toBeDefined();
-    if (kibanaGroup && isActionGroup(kibanaGroup)) {
-      expect(kibanaGroup.options).toHaveLength(1);
+    expect(externalGroup).toBeDefined();
+    if (externalGroup && isActionGroup(externalGroup)) {
+      expect(externalGroup.options).toHaveLength(1);
+      expect(externalGroup.options[0].id).toBe('custom.connector');
     }
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.test.ts
@@ -24,15 +24,8 @@ jest.mock('../../../trigger_schemas', () => ({
   triggerSchemas: { getTriggerDefinitions: jest.fn(() => []) },
 }));
 jest.mock('@kbn/workflows', () => ({
+  ...jest.requireActual('@kbn/workflows'),
   isDynamicConnector: jest.fn(),
-  StepCategory: {
-    Elasticsearch: 'elasticsearch',
-    External: 'external',
-    Ai: 'ai',
-    Kibana: 'kibana',
-    Data: 'data',
-    FlowControl: 'flowControl',
-  },
 }));
 jest.mock('../../../shared/ui/step_icons/get_step_icon_type', () => ({
   getStepIconType: jest.fn(),

--- a/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
@@ -7,6 +7,7 @@
 
 import { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { StepCategory } from '@kbn/workflows';
 import { JsonModelShapeSchema } from '@kbn/workflows/spec/schema/common/json_model_shape_schema';
 import { i18n } from '@kbn/i18n';
 
@@ -127,7 +128,7 @@ export const runAgentStepCommonDefinition: CommonStepDefinition<
   RunAgentStepConfigSchema
 > = {
   id: RunAgentStepTypeId,
-  category: 'ai',
+  category: StepCategory.Ai,
   label: i18n.translate('xpack.agentBuilder.runAgentStep.label', {
     defaultMessage: 'Run Agent',
   }),

--- a/x-pack/solutions/workplaceai/plugins/workplace_ai_app/common/steps/rerank/rerank_step.ts
+++ b/x-pack/solutions/workplaceai/plugins/workplace_ai_app/common/steps/rerank/rerank_step.ts
@@ -8,6 +8,7 @@
 import { z } from '@kbn/zod/v4';
 import { i18n } from '@kbn/i18n';
 import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { StepCategory } from '@kbn/workflows';
 
 /**
  * Step type ID for the rerank workflow step
@@ -84,7 +85,7 @@ export const rerankStepCommonDefinition: CommonStepDefinition<
   typeof RerankConfigSchema
 > = {
   id: RerankStepTypeId,
-  category: 'elasticsearch',
+  category: StepCategory.Elasticsearch,
   label: i18n.translate('xpack.workplaceai.rerankStep.label', {
     defaultMessage: 'Rerank Results',
   }),


### PR DESCRIPTION
## Summary

This PR addresses several CI failures related to type checking and Jest tests in the workflows feature.

1.  **Type Check Failures**: Corrected type errors where step definitions were using string literals (e.g., `'external'`, `'data'`, `'ai'`, `'elasticsearch'`) for the `category` property instead of the `StepCategory` enum values. This was fixed in `external_step.ts`, `setvat_step.ts`, `run_agent_step.ts`, and `rerank_step.ts`.
2.  **Jest Test Failures (`getActionOptions.test.ts`)**: Updated tests in `get_action_options.test.ts` to align with a previous refactor that changed action category handling from `actionsMenuGroup` to `customStepDefinition.category`. This involved updating the `@kbn/workflows` mock, adjusting mock step definitions to use `category: StepCategory.Kibana`, and modifying a test case to verify category-based grouping.
3.  **Unrelated Failures**: Other reported CI failures (Discover sidebar, Task Manager integration, Agent Builder API Smoke Tests) were identified as unrelated or flaky and are not addressed by this PR.

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [x] This PR introduces no significant risks. The changes are primarily type corrections and test updates to align with existing code logic, with no intended changes to runtime behavior or new features.

---

### Release Notes

**Bug Fixes**
*   Fixed type check failures in workflow step definitions by enforcing `StepCategory` enum usage.
*   Resolved Jest test failures in `getActionOptions` by updating tests to reflect current category handling logic.

---
<p><a href="https://cursor.com/agents/bc-a1fb2b8d-341b-4469-9f96-cc9e5619780c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1fb2b8d-341b-4469-9f96-cc9e5619780c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

